### PR TITLE
fix: Cmake static linker flag and cmake supress deprecate warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 project(snooze C)
 
 set(src snooze.c)

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY snooze.c CMakeLists.txt ./
 
 # Create build directory and compile with CMake
 RUN mkdir build && cd build && \
-    cmake -DCMAKE_BUILD_TYPE=MinSizeRel .. && \
+    cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_EXE_LINKER_FLAGS="-static" .. && \
     make -j$(nproc) && \
     strip --strip-all snooze
 


### PR DESCRIPTION
### **Why:**

When running the Docker command `docker run --rm -it spurin/snooze:latest`, the following error occurs due to a missing dynamic library:

```
{"msg":"exec container process (missing dynamic library?) `/snooze`: No such file or directory","level":"error","time":"2025-05-17T19:47:14.831950Z"}
```

**Reported Architecture:** arm64

### **Solution:**

To address this, the `make` command was updated to include a flag for the Static EXE Linker, ensuring the binary is built with static linking instead of dynamic. Additionally, the CMake deprecation warning related to the minimum make version was suppressed.
